### PR TITLE
Fix peer ID generation

### DIFF
--- a/cmd/koinos-p2p/main.go
+++ b/cmd/koinos-p2p/main.go
@@ -21,30 +21,30 @@ func main() {
 	rand.Seed(time.Now().UTC().UnixNano())
 
 	var addr = flag.StringP("listen", "l", "/ip4/127.0.0.1/tcp/8888", "The multiaddress on which the node will listen")
-	var seed = flag.Uint64P("seed", "s", 0, "Seed with which the node will generate an ID (use 0 for a randomized seed)")
-	var amqpFlag = flag.StringP("amqp", "a", "amqp://guest:guest@localhost:5672/", "AMQP server URL")
-	var peerFlags = flag.StringSliceP("peer", "p", []string{}, "Address of a peer to which to connect (may specify multiple)")
-	var directFlags = flag.StringSliceP("direct", "d", []string{}, "Address of a peer to connect using gossipsub.WithDirectPeers (may specify multiple) (should be reciprocal)")
-	var pexFlag = flag.BoolP("pex", "x", true, "Exchange peers with other nodes")
-	var bootstrapFlag = flag.BoolP("bootstrap", "b", false, "Function as bootstrap node (always PRUNE, see libp2p gossip pex docs)")
-	var gossipFlag = flag.BoolP("gossip", "g", true, "Enable gossip mode")
-	var forceGossipFlag = flag.BoolP("force-gossip", "G", false, "Force gossip mode")
-	var verboseFlag = flag.BoolP("verbose", "v", false, "Enable verbose debug messages")
+	var seed = flag.StringP("seed", "s", "", "Seed string with which the node will generate an ID (A randomized seed will be generated if none is provided)")
+	var amqp = flag.StringP("amqp", "a", "amqp://guest:guest@localhost:5672/", "AMQP server URL")
+	var peerAddresses = flag.StringSliceP("peer", "p", []string{}, "Address of a peer to which to connect (may specify multiple)")
+	var directAddresses = flag.StringSliceP("direct", "d", []string{}, "Address of a peer to connect using gossipsub.WithDirectPeers (may specify multiple) (should be reciprocal)")
+	var peerExchange = flag.BoolP("pex", "x", true, "Exchange peers with other nodes")
+	var bootstrap = flag.BoolP("bootstrap", "b", false, "Function as bootstrap node (always PRUNE, see libp2p gossip pex docs)")
+	var gossip = flag.BoolP("gossip", "g", true, "Enable gossip mode")
+	var forceGossip = flag.BoolP("force-gossip", "G", false, "Force gossip mode")
+	var verbose = flag.BoolP("verbose", "v", false, "Enable verbose debug messages")
 
 	flag.Parse()
 
-	mq := koinosmq.NewKoinosMQ(*amqpFlag)
+	mq := koinosmq.NewKoinosMQ(*amqp)
 
 	config := options.NewConfig()
 
-	config.NodeOptions.EnablePeerExchange = *pexFlag
-	config.NodeOptions.EnableBootstrap = *bootstrapFlag
-	config.NodeOptions.EnableGossip = *gossipFlag
-	config.NodeOptions.EnableDebugMessages = *verboseFlag
-	config.NodeOptions.ForceGossip = *forceGossipFlag
+	config.NodeOptions.EnablePeerExchange = *peerExchange
+	config.NodeOptions.EnableBootstrap = *bootstrap
+	config.NodeOptions.EnableGossip = *gossip
+	config.NodeOptions.EnableDebugMessages = *verbose
+	config.NodeOptions.ForceGossip = *forceGossip
 
-	config.NodeOptions.InitialPeers = *peerFlags
-	config.NodeOptions.DirectPeers = *directFlags
+	config.NodeOptions.InitialPeers = *peerAddresses
+	config.NodeOptions.DirectPeers = *directAddresses
 
 	node, err := node.NewKoinosP2PNode(context.Background(), *addr, rpc.NewKoinosRPC(mq), *seed, config)
 	if err != nil {

--- a/cmd/koinos-p2p/main.go
+++ b/cmd/koinos-p2p/main.go
@@ -3,9 +3,11 @@ package main
 import (
 	"context"
 	"log"
+	"math/rand"
 	"os"
 	"os/signal"
 	"syscall"
+	"time"
 
 	koinosmq "github.com/koinos/koinos-mq-golang"
 	"github.com/koinos/koinos-p2p/internal/node"
@@ -15,8 +17,11 @@ import (
 )
 
 func main() {
+	// Seed the random number generator
+	rand.Seed(time.Now().UTC().UnixNano())
+
 	var addr = flag.StringP("listen", "l", "/ip4/127.0.0.1/tcp/8888", "The multiaddress on which the node will listen")
-	var seed = flag.IntP("seed", "s", 0, "Random seed with which the node will generate an ID")
+	var seed = flag.Uint64P("seed", "s", 0, "Seed with which the node will generate an ID (use 0 for a randomized seed)")
 	var amqpFlag = flag.StringP("amqp", "a", "amqp://guest:guest@localhost:5672/", "AMQP server URL")
 	var peerFlags = flag.StringSliceP("peer", "p", []string{}, "Address of a peer to which to connect (may specify multiple)")
 	var directFlags = flag.StringSliceP("direct", "d", []string{}, "Address of a peer to connect using gossipsub.WithDirectPeers (may specify multiple) (should be reciprocal)")
@@ -41,7 +46,7 @@ func main() {
 	config.NodeOptions.InitialPeers = *peerFlags
 	config.NodeOptions.DirectPeers = *directFlags
 
-	node, err := node.NewKoinosP2PNode(context.Background(), *addr, rpc.NewKoinosRPC(mq), int64(*seed), config)
+	node, err := node.NewKoinosP2PNode(context.Background(), *addr, rpc.NewKoinosRPC(mq), *seed, config)
 	if err != nil {
 		panic(err)
 	}

--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -45,7 +45,7 @@ func NewKoinosP2PNode(ctx context.Context, listenAddr string, rpc rpc.RPC, seed 
 		r = mrand.New(mrand.NewSource(seed))
 	}
 
-	privateKey, _, err := crypto.GenerateKeyPairWithReader(crypto.RSA, 2048, r)
+	privateKey, _, err := crypto.GenerateECDSAKeyPair(r)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -7,7 +7,6 @@ import (
 	"io"
 	"log"
 	"math/rand"
-	mrand "math/rand"
 	"time"
 
 	"github.com/koinos/koinos-p2p/internal/options"
@@ -48,7 +47,7 @@ func NewKoinosP2PNode(ctx context.Context, listenAddr string, rpc rpc.RPC, seed 
 		log.Printf("Using random seed: %d", seed)
 	}
 
-	r = mrand.New(mrand.NewSource(int64(seed)))
+	r = rand.New(rand.NewSource(int64(seed)))
 
 	privateKey, _, err := crypto.GenerateECDSAKeyPair(r)
 	if err != nil {

--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -2,11 +2,11 @@ package node
 
 import (
 	"context"
-	crand "crypto/rand"
 	"encoding/json"
 	"fmt"
 	"io"
 	"log"
+	"math/rand"
 	mrand "math/rand"
 	"time"
 
@@ -36,14 +36,19 @@ type KoinosP2PNode struct {
 // NewKoinosP2PNode creates a libp2p node object listening on the given multiaddress
 // uses secio encryption on the wire
 // listenAddr is a multiaddress string on which to listen
-// seed is the random seed to use for key generation. Use a negative number for a random seed.
-func NewKoinosP2PNode(ctx context.Context, listenAddr string, rpc rpc.RPC, seed int64, config *options.Config) (*KoinosP2PNode, error) {
+// seed is the random seed to use for key generation. Use 0 for a random seed.
+func NewKoinosP2PNode(ctx context.Context, listenAddr string, rpc rpc.RPC, seed uint64, config *options.Config) (*KoinosP2PNode, error) {
 	var r io.Reader
+
 	if seed == 0 {
-		r = crand.Reader
-	} else {
-		r = mrand.New(mrand.NewSource(seed))
+		for seed == 0 {
+			seed = rand.Uint64()
+		}
+
+		log.Printf("Using random seed: %d", seed)
 	}
+
+	r = mrand.New(mrand.NewSource(int64(seed)))
 
 	privateKey, _, err := crypto.GenerateECDSAKeyPair(r)
 	if err != nil {

--- a/internal/node/node_test.go
+++ b/internal/node/node_test.go
@@ -104,7 +104,7 @@ func TestBasicNode(t *testing.T) {
 	rpc := NewTestRPC(128)
 
 	// With an explicit seed
-	bn, err := NewKoinosP2PNode(ctx, "/ip4/127.0.0.1/tcp/8765", rpc, 1234, options.NewConfig())
+	bn, err := NewKoinosP2PNode(ctx, "/ip4/127.0.0.1/tcp/8765", rpc, "test1", options.NewConfig())
 	if err != nil {
 		t.Error(err)
 	}
@@ -117,8 +117,8 @@ func TestBasicNode(t *testing.T) {
 
 	bn.Close()
 
-	// With 0 seed
-	bn, err = NewKoinosP2PNode(ctx, "/ip4/127.0.0.1/tcp/8765", rpc, 0, options.NewConfig())
+	// With blank seed
+	bn, err = NewKoinosP2PNode(ctx, "/ip4/127.0.0.1/tcp/8765", rpc, "", options.NewConfig())
 	if err != nil {
 		t.Error(err)
 	}
@@ -126,7 +126,7 @@ func TestBasicNode(t *testing.T) {
 	bn.Close()
 
 	// Give an invalid listen address
-	bn, err = NewKoinosP2PNode(ctx, "---", rpc, 0, options.NewConfig())
+	bn, err = NewKoinosP2PNode(ctx, "---", rpc, "", options.NewConfig())
 	if err == nil {
 		bn.Close()
 		t.Error("Starting a node with an invalid address should give an error, but it did not")

--- a/internal/p2p_test.go
+++ b/internal/p2p_test.go
@@ -225,7 +225,7 @@ func createTestClients(listenRPC rpc.RPC, sendRPC rpc.RPC) (*node.KoinosP2PNode,
 	config.DownloadManagerOptions.MaxDownloadDepth = 15
 	config.DownloadManagerOptions.MaxDownloadsInFlight = 25
 	config.SetEnableDebugMessages(false)
-	listenNode, err := node.NewKoinosP2PNode(context.Background(), "/ip4/127.0.0.1/tcp/8765", listenRPC, 1234, config)
+	listenNode, err := node.NewKoinosP2PNode(context.Background(), "/ip4/127.0.0.1/tcp/8765", listenRPC, "test1", config)
 	if err != nil {
 		return nil, nil, nil, nil, err
 	}
@@ -234,7 +234,7 @@ func createTestClients(listenRPC rpc.RPC, sendRPC rpc.RPC) (*node.KoinosP2PNode,
 		return nil, nil, nil, nil, err
 	}
 
-	sendNode, err := node.NewKoinosP2PNode(context.Background(), "/ip4/127.0.0.1/tcp/8888", sendRPC, 2345, config)
+	sendNode, err := node.NewKoinosP2PNode(context.Background(), "/ip4/127.0.0.1/tcp/8888", sendRPC, "test2", config)
 	if err != nil {
 		return nil, nil, nil, nil, err
 	}

--- a/internal/protocol/peer_handler.go
+++ b/internal/protocol/peer_handler.go
@@ -92,7 +92,7 @@ func (h *PeerHandler) requestDownload(ctx context.Context, req BlockDownloadRequ
 				if err == nil {
 					log.Printf("  - Got block: %s\n", rpcRespStr)
 				} else {
-					log.Printf("  - Got unmarshalable block\n", rpcRespStr)
+					log.Printf("  - Got unmarshalable block: %s\n", rpcRespStr)
 				}
 			}
 		}


### PR DESCRIPTION
It now will properly produce the same ID given the same key. 

Some cleanup was also done; 
- If generating a random seed, it will log that seed so it can be reused by the node operator.
- Seeds are now uint64 to avoid weird negative seeds

Resolves #66