### PR TITLE
Plugins

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,3 +20,7 @@ require (
 	github.com/stretchr/testify v1.7.0
 	google.golang.org/protobuf v1.28.0
 )
+
+replace (
+	github.com/koinos/koinos-proto-golang v0.2.1-0.20220304200226-d96c9cf694de => "/Users/rr/Documents/blockchain/koinos-proto/build/go/github.com/koinos/koinos-proto-golang"
+)

--- a/go.mod
+++ b/go.mod
@@ -22,5 +22,5 @@ require (
 )
 
 replace (
-	github.com/koinos/koinos-proto-golang v0.2.1-0.20220304200226-d96c9cf694de => "/Users/rr/Documents/blockchain/koinos-proto/build/go/github.com/koinos/koinos-proto-golang"
+	github.com/koinos/koinos-proto-golang v0.2.1-0.20220304200226-d96c9cf694de => github.com/roaminroe/koinos-proto-golang v0.0.0-20220511165109-9d11027e06ed
 )

--- a/go.sum
+++ b/go.sum
@@ -1170,6 +1170,8 @@ github.com/raulk/go-watchdog v1.2.0/go.mod h1:lzSbAl5sh4rtI8tYHU01BWIDzgzqaQLj6R
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/retailnext/hllpp v1.0.1-0.20180308014038-101a6d2f8b52/go.mod h1:RDpi1RftBQPUCDRw6SmxeaREsAaRKnOclghuzp/WRzc=
 github.com/rjeczalik/notify v0.9.1/go.mod h1:rKwnCoCGeuQnwBtTSPL9Dad03Vh2n40ePRrjvIXnJho=
+github.com/roaminroe/koinos-proto-golang v0.0.0-20220511165109-9d11027e06ed h1:xoihLhLq+UMDNwvdvnOhDTsGGZS/AxzISGtosatC+bk=
+github.com/roaminroe/koinos-proto-golang v0.0.0-20220511165109-9d11027e06ed/go.mod h1:zX+WYuPUqYt+yVAxIWFpQ3zz2UQEfka5RycX8lLeiHU=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=

--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -237,7 +237,7 @@ func (n *KoinosP2PNode) handlePluginBroadcast(topic string, data []byte) {
 		return
 	}
 
-	// If gossip is enabled publish the block
+	// If gossip is enabled publish the data
 	if n.GossipToggle.IsEnabled() {
 		err := n.Gossip.PublishPluginData(context.Background(), topic, pluginBroadcast.Data)
 		if err != nil {

--- a/internal/node/node_test.go
+++ b/internal/node/node_test.go
@@ -131,7 +131,7 @@ func TestBasicNode(t *testing.T) {
 	rpc := NewTestRPC(128)
 
 	// With an explicit seed
-	bn, err := NewKoinosP2PNode(ctx, "/ip4/127.0.0.1/tcp/8765", rpc, nil, "test1", options.NewConfig())
+	bn, err := NewKoinosP2PNode(ctx, "/ip4/127.0.0.1/tcp/8765", rpc, nil, nil, "test1", options.NewConfig())
 	if err != nil {
 		t.Error(err)
 	}
@@ -145,7 +145,7 @@ func TestBasicNode(t *testing.T) {
 	bn.Close()
 
 	// With blank seed
-	bn, err = NewKoinosP2PNode(ctx, "/ip4/127.0.0.1/tcp/8765", rpc, nil, "", options.NewConfig())
+	bn, err = NewKoinosP2PNode(ctx, "/ip4/127.0.0.1/tcp/8765", rpc, nil, nil, "", options.NewConfig())
 	if err != nil {
 		t.Error(err)
 	}
@@ -153,7 +153,7 @@ func TestBasicNode(t *testing.T) {
 	bn.Close()
 
 	// Give an invalid listen address
-	bn, err = NewKoinosP2PNode(ctx, "---", rpc, nil, "", options.NewConfig())
+	bn, err = NewKoinosP2PNode(ctx, "---", rpc, nil, nil, "", options.NewConfig())
 	if err == nil {
 		bn.Close()
 		t.Error("Starting a node with an invalid address should give an error, but it did not")

--- a/internal/options/node_options.go
+++ b/internal/options/node_options.go
@@ -10,6 +10,9 @@ type NodeOptions struct {
 
 	// Force gossip mode on startup
 	ForceGossip bool
+
+	// Plugins allowed
+	Plugins []string
 }
 
 // NewNodeOptions creates a NodeOptions object which controls how p2p works

--- a/internal/p2p/connection_manager.go
+++ b/internal/p2p/connection_manager.go
@@ -44,6 +44,7 @@ type ConnectionManager struct {
 	client *gorpc.Client
 
 	localRPC    rpc.LocalRPC
+	pluginsRPC  map[string]*rpc.PluginRPC
 	peerOpts    *options.PeerConnectionOptions
 	libProvider LastIrreversibleBlockProvider
 
@@ -61,6 +62,7 @@ type ConnectionManager struct {
 func NewConnectionManager(
 	host host.Host,
 	localRPC rpc.LocalRPC,
+	pluginsRPC map[string]*rpc.PluginRPC,
 	peerOpts *options.PeerConnectionOptions,
 	libProvider LastIrreversibleBlockProvider,
 	initialPeers []string,
@@ -73,6 +75,7 @@ func NewConnectionManager(
 		client:                   gorpc.NewClient(host, rpc.PeerRPCID),
 		server:                   gorpc.NewServer(host, rpc.PeerRPCID),
 		localRPC:                 localRPC,
+		pluginsRPC:               pluginsRPC,
 		peerOpts:                 peerOpts,
 		libProvider:              libProvider,
 		initialPeers:             make(map[peer.ID]peer.AddrInfo),
@@ -85,7 +88,7 @@ func NewConnectionManager(
 	}
 
 	log.Debug("Registering Peer RPC Service")
-	err := connectionManager.server.Register(rpc.NewPeerRPCService(connectionManager.localRPC))
+	err := connectionManager.server.Register(rpc.NewPeerRPCService(connectionManager.localRPC, connectionManager.pluginsRPC))
 	if err != nil {
 		log.Errorf("Error registering Peer RPC Service: %s", err.Error())
 		panic(err)

--- a/internal/p2p_test.go
+++ b/internal/p2p_test.go
@@ -209,13 +209,13 @@ func SetUnitTestOptions(config *options.Config) {
 }
 
 func createTestClients(listenRPC rpc.LocalRPC, listenConfig *options.Config, sendRPC rpc.LocalRPC, sendConfig *options.Config) (*node.KoinosP2PNode, *node.KoinosP2PNode, multiaddr.Multiaddr, multiaddr.Multiaddr, error) {
-	listenNode, err := node.NewKoinosP2PNode(context.Background(), "/ip4/127.0.0.1/tcp/8765", listenRPC, nil, "test1", listenConfig)
+	listenNode, err := node.NewKoinosP2PNode(context.Background(), "/ip4/127.0.0.1/tcp/8765", listenRPC, nil, nil, "test1", listenConfig)
 	if err != nil {
 		return nil, nil, nil, nil, err
 	}
 	listenNode.Start(context.Background())
 
-	sendNode, err := node.NewKoinosP2PNode(context.Background(), "/ip4/127.0.0.1/tcp/8888", sendRPC, nil, "test2", sendConfig)
+	sendNode, err := node.NewKoinosP2PNode(context.Background(), "/ip4/127.0.0.1/tcp/8888", sendRPC, nil, nil, "test2", sendConfig)
 	if err != nil {
 		return nil, nil, nil, nil, err
 	}

--- a/internal/p2perrors/errors.go
+++ b/internal/p2perrors/errors.go
@@ -43,4 +43,10 @@ var (
 
 	// ErrProcessRequestTimeout represents an in process asynchronous request time out
 	ErrProcessRequestTimeout = errors.New("in process request timed out")
+
+	// ErrGossipManagerPluginNotSet represents an error when a gossip manager is not available for a plugin
+	ErrGossipManagerPluginNotSet = errors.New("gossip manager not set for plugin")
+
+	// ErrPluginNotAvailable represents an error when a peer does not have a plugin available
+	ErrPluginNotAvailable = errors.New("plugin not available")
 )

--- a/internal/rpc/peer_rpc.go
+++ b/internal/rpc/peer_rpc.go
@@ -100,22 +100,3 @@ func (p *PeerRPC) GetBlocks(ctx context.Context, headBlockID multihash.Multihash
 
 	return blocks, nil
 }
-
-// SubmitDataPlugin rpc call
-func (p *PeerRPC) SubmitDataPlugin(ctx context.Context, pluginName string, data []byte) (result []byte, err error) {
-	rpcReq := &SubmitDataPluginRequest{
-		PluginName: pluginName,
-		Data:       data,
-	}
-	rpcResp := &SubmitDataPluginResponse{}
-
-	err = p.client.CallContext(ctx, p.peerID, "PeerRPCService", "SubmitDataPlugin", rpcReq, rpcResp)
-	if err != nil {
-		if errors.Is(err, context.DeadlineExceeded) {
-			return nil, fmt.Errorf("%w, %s", p2perrors.ErrPeerRPCTimeout, err)
-		}
-		return nil, fmt.Errorf("%w, %s", p2perrors.ErrPeerRPC, err)
-	}
-
-	return rpcResp.Data, nil
-}

--- a/internal/rpc/peer_rpc.go
+++ b/internal/rpc/peer_rpc.go
@@ -100,3 +100,22 @@ func (p *PeerRPC) GetBlocks(ctx context.Context, headBlockID multihash.Multihash
 
 	return blocks, nil
 }
+
+// SubmitDataPlugin rpc call
+func (p *PeerRPC) SubmitDataPlugin(ctx context.Context, pluginName string, data []byte) (result []byte, err error) {
+	rpcReq := &SubmitDataPluginRequest{
+		PluginName: pluginName,
+		Data:       data,
+	}
+	rpcResp := &SubmitDataPluginResponse{}
+
+	err = p.client.CallContext(ctx, p.peerID, "PeerRPCService", "SubmitDataPlugin", rpcReq, rpcResp)
+	if err != nil {
+		if errors.Is(err, context.DeadlineExceeded) {
+			return nil, fmt.Errorf("%w, %s", p2perrors.ErrPeerRPCTimeout, err)
+		}
+		return nil, fmt.Errorf("%w, %s", p2perrors.ErrPeerRPC, err)
+	}
+
+	return rpcResp.Data, nil
+}

--- a/internal/rpc/peer_rpc_service.go
+++ b/internal/rpc/peer_rpc_service.go
@@ -3,9 +3,7 @@ package rpc
 import (
 	"context"
 	"errors"
-	"fmt"
 
-	"github.com/koinos/koinos-p2p/internal/p2perrors"
 	"github.com/multiformats/go-multihash"
 	"google.golang.org/protobuf/proto"
 )
@@ -53,17 +51,6 @@ type GetBlocksRequest struct {
 // GetBlocksResponse return
 type GetBlocksResponse struct {
 	Blocks [][]byte
-}
-
-// SubmitDataPluginRequest args
-type SubmitDataPluginRequest struct {
-	PluginName string
-	Data       []byte
-}
-
-// SubmitDataPluginResponse return
-type SubmitDataPluginResponse struct {
-	Data []byte
 }
 
 // PeerRPCService implements a libp2p_rpc service
@@ -132,23 +119,6 @@ func (p *PeerRPCService) GetBlocks(ctx context.Context, request *GetBlocksReques
 			return err
 		}
 	}
-
-	return nil
-}
-
-// SubmitDataPlugin peer rpc implementation
-func (p *PeerRPCService) SubmitDataPlugin(ctx context.Context, request *SubmitDataPluginRequest, response *SubmitDataPluginResponse) error {
-	pluginRpc, ok := p.plugins[request.PluginName]
-	if !ok {
-		return fmt.Errorf("%w, %s", p2perrors.ErrPluginNotAvailable, request.PluginName)
-	}
-
-	rpcResult, err := pluginRpc.SubmitData(ctx, request.Data)
-	if err != nil {
-		return err
-	}
-
-	response.Data = rpcResult
 
 	return nil
 }

--- a/internal/rpc/plugin_rpc.go
+++ b/internal/rpc/plugin_rpc.go
@@ -1,0 +1,97 @@
+package rpc
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"google.golang.org/protobuf/proto"
+
+	koinosmq "github.com/koinos/koinos-mq-golang"
+	"github.com/koinos/koinos-p2p/internal/p2perrors"
+	"github.com/koinos/koinos-proto-golang/koinos/rpc"
+	"github.com/koinos/koinos-proto-golang/koinos/rpc/plugin"
+)
+
+const (
+	PluginPrefix = "plugin."
+)
+
+// PluginRPC implements LocalRPC implementation by communicating with a local plugin via AMQP
+type PluginRPC struct {
+	mq   *koinosmq.Client
+	Name string
+}
+
+// NewPluginRPC factory
+func NewPluginRPC(mq *koinosmq.Client, name string) *PluginRPC {
+	rpc := new(PluginRPC)
+	rpc.mq = mq
+	rpc.Name = PluginPrefix + name
+	return rpc
+}
+
+// IsConnectedToPlugin returns if the AMQP connection can currently communicate
+// with the plugin microservice.
+func (k *PluginRPC) IsConnectedToPlugin(ctx context.Context) (bool, error) {
+	args := &plugin.PluginRequest{
+		Request: &plugin.PluginRequest_Reserved{
+			Reserved: &rpc.ReservedRpc{},
+		},
+	}
+
+	data, err := proto.Marshal(args)
+	if err != nil {
+		return false, fmt.Errorf("%w IsConnectedToPlugin, %s", p2perrors.ErrSerialization, err)
+	}
+
+	var responseBytes []byte
+	responseBytes, err = k.mq.RPCContext(ctx, "application/octet-stream", k.Name, data)
+	if err != nil {
+		if errors.Is(err, context.DeadlineExceeded) {
+			return false, fmt.Errorf("%w IsConnectedToPlugin, %s", p2perrors.ErrLocalRPCTimeout, err)
+		}
+		return false, fmt.Errorf("%w IsConnectedToPlugin, %s", p2perrors.ErrLocalRPC, err)
+	}
+
+	responseVariant := &plugin.PluginResponse{}
+	err = proto.Unmarshal(responseBytes, responseVariant)
+	if err != nil {
+		return false, fmt.Errorf("%w IsConnectedToPlugin, %s", p2perrors.ErrDeserialization, err)
+	}
+
+	return true, nil
+}
+
+// SubmitData submits data to the plugin microservice.
+func (k *PluginRPC) SubmitData(ctx context.Context, data []byte) ([]byte, error) {
+	args := &plugin.PluginRequest{
+		Request: &plugin.PluginRequest_SubmitData{
+			SubmitData: &plugin.SubmitDataRequest{
+				Data: data,
+			},
+		},
+	}
+
+	data, err := proto.Marshal(args)
+	if err != nil {
+		return nil, fmt.Errorf("%w SubmitData, %s", p2perrors.ErrSerialization, err)
+	}
+
+	var responseBytes []byte
+	responseBytes, err = k.mq.RPCContext(ctx, "application/octet-stream", k.Name, data)
+	if err != nil {
+		if errors.Is(err, context.DeadlineExceeded) {
+			return nil, fmt.Errorf("%w SubmitData, %s", p2perrors.ErrLocalRPCTimeout, err)
+		}
+		return nil, fmt.Errorf("%w SubmitData, %s", p2perrors.ErrLocalRPC, err)
+	}
+
+	responseVariant := &plugin.PluginResponse{}
+	err = proto.Unmarshal(responseBytes, responseVariant)
+	if err != nil {
+		return nil, fmt.Errorf("%w SubmitData, %s", p2perrors.ErrDeserialization, err)
+	}
+
+	return responseVariant.GetSubmitData().Data, nil
+}

--- a/internal/rpc/plugin_rpc.go
+++ b/internal/rpc/plugin_rpc.go
@@ -64,7 +64,7 @@ func (k *PluginRPC) IsConnectedToPlugin(ctx context.Context) (bool, error) {
 }
 
 // SubmitData submits data to the plugin microservice.
-func (k *PluginRPC) SubmitData(ctx context.Context, data []byte) ([]byte, error) {
+func (k *PluginRPC) SubmitData(ctx context.Context, data []byte) error {
 	args := &plugin.PluginRequest{
 		Request: &plugin.PluginRequest_SubmitData{
 			SubmitData: &plugin.SubmitDataRequest{
@@ -75,23 +75,23 @@ func (k *PluginRPC) SubmitData(ctx context.Context, data []byte) ([]byte, error)
 
 	data, err := proto.Marshal(args)
 	if err != nil {
-		return nil, fmt.Errorf("%w SubmitData, %s", p2perrors.ErrSerialization, err)
+		return fmt.Errorf("%w SubmitData, %s", p2perrors.ErrSerialization, err)
 	}
 
 	var responseBytes []byte
 	responseBytes, err = k.mq.RPCContext(ctx, "application/octet-stream", k.Name, data)
 	if err != nil {
 		if errors.Is(err, context.DeadlineExceeded) {
-			return nil, fmt.Errorf("%w SubmitData, %s", p2perrors.ErrLocalRPCTimeout, err)
+			return fmt.Errorf("%w SubmitData, %s", p2perrors.ErrLocalRPCTimeout, err)
 		}
-		return nil, fmt.Errorf("%w SubmitData, %s", p2perrors.ErrLocalRPC, err)
+		return fmt.Errorf("%w SubmitData, %s", p2perrors.ErrLocalRPC, err)
 	}
 
 	responseVariant := &plugin.PluginResponse{}
 	err = proto.Unmarshal(responseBytes, responseVariant)
 	if err != nil {
-		return nil, fmt.Errorf("%w SubmitData, %s", p2perrors.ErrDeserialization, err)
+		return fmt.Errorf("%w SubmitData, %s", p2perrors.ErrDeserialization, err)
 	}
 
-	return responseVariant.GetSubmitData().Data, nil
+	return nil
 }


### PR DESCRIPTION
## Brief description
This PR adds the ability for node operator to run addional microservices that can leverage the already established P2P network created for the blockchain:

- a new "flag" or yaml option called `plugins` was added, it accepts an array of strings.
- upon startup, the P2P service, for each plugin found in the flag `plugins`:
    - connects to the plugin's microservice via `AMQP`
    - once connected, sets up an `AMQP broadcast handler` that will listen to the topic `plugin.PLUGIN_NAME`
    - sets up a `Gossip Manager` that will listen to P2P messages gossiped on the topic `plugin.PLUGIN_NAME`
- gossiped P2P messages are not validated at the P2P microservice level, the data is simply passed onto the plugin microservice
- only messages that were sent by other peers are forwarded to a plugin

Limitations:
- `libp2p` does not propagate gossiped messages that are not handled by a node, meaning that a node running a plugin needs to be connected to other nodes that run the same plugin in order to receive P2P messages... (I asked the team behind the go-libp2p library and they told me you can tell a node to `relay` gossiped messages for a given topic, but you'll need to know the plugins' topics before turning on the node)

Additional changes:
- requires to add a new proto message in the Koinos RPC proto package, see this fork: https://github.com/roaminroe/koinos-proto/blob/plugins/koinos/rpc/plugin/plugin_rpc.proto

## Checklist

- [ ] I have built this pull request locally
- [ ] I have ran the unit tests locally
- [ ] I have manually tested this pull request
- [ ] I have reviewed my pull request
- [ ] I have added any relevant tests

## Demonstration
<!-- If applicable, attach screenshot or terminal output of working code -->
