### PR TITLE
Optimize sync

### DIFF
--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -181,7 +181,9 @@ func NewKoinosP2PNode(ctx context.Context, listenAddr string, localRPC rpc.Local
 		node.Options.InitialPeers,
 		node.PeerErrorChan,
 		node.GossipVoteChan,
-		node.PeerDisconnectedChan)
+		node.PeerDisconnectedChan,
+		node.BlockApplicator,
+	)
 
 	return node, nil
 }

--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -182,8 +182,7 @@ func NewKoinosP2PNode(ctx context.Context, listenAddr string, localRPC rpc.Local
 		node.PeerErrorChan,
 		node.GossipVoteChan,
 		node.PeerDisconnectedChan,
-		node.BlockApplicator,
-	)
+		node.BlockApplicator)
 
 	return node, nil
 }

--- a/internal/options/block_applicator_options.go
+++ b/internal/options/block_applicator_options.go
@@ -2,7 +2,7 @@ package options
 
 const (
 	maxPendingBlocksDefault = 2500
-	maxHeightDeltaDefault   = 1000
+	maxHeightDeltaDefault   = 60
 )
 
 // BlockApplicatorOptions are options for BlockApplicator

--- a/internal/options/block_applicator_options.go
+++ b/internal/options/block_applicator_options.go
@@ -2,7 +2,7 @@ package options
 
 const (
 	maxPendingBlocksDefault = 2500
-	maxHeightDeltaDefault   = 10
+	maxHeightDeltaDefault   = 1000
 )
 
 // BlockApplicatorOptions are options for BlockApplicator

--- a/internal/options/peer_connection_options.go
+++ b/internal/options/peer_connection_options.go
@@ -13,37 +13,40 @@ type Checkpoint struct {
 }
 
 const (
-	localRPCTimeoutDefault       = time.Second * 6
-	remoteRPCTimeoutDefault      = time.Second * 6
-	blockRequestBatchSizeDefault = 1000
-	blockRequestTimeoutDefault   = time.Second * 6
-	handshakeRetryTimeDefault    = time.Second * 6
-	syncedBlockDeltaDefault      = 5
-	syncedPingTimeDefault        = time.Second * 10
+	localRPCTimeoutDefault        = time.Second * 6
+	blockApplicatorTimeoutDefault = localRPCTimeoutDefault * 2
+	remoteRPCTimeoutDefault       = time.Second * 6
+	blockRequestBatchSizeDefault  = 1000
+	blockRequestTimeoutDefault    = time.Second * 6
+	handshakeRetryTimeDefault     = time.Second * 6
+	syncedBlockDeltaDefault       = 5
+	syncedPingTimeDefault         = time.Second * 10
 )
 
 // PeerConnectionOptions are options for PeerConnection
 type PeerConnectionOptions struct {
-	Checkpoints           []Checkpoint
-	LocalRPCTimeout       time.Duration
-	RemoteRPCTimeout      time.Duration
-	BlockRequestBatchSize uint64
-	BlockRequestTimeout   time.Duration
-	HandshakeRetryTime    time.Duration
-	SyncedBlockDelta      uint64
-	SyncedPingTime        time.Duration
+	Checkpoints            []Checkpoint
+	LocalRPCTimeout        time.Duration
+	BlockApplicatorTimeout time.Duration
+	RemoteRPCTimeout       time.Duration
+	BlockRequestBatchSize  uint64
+	BlockRequestTimeout    time.Duration
+	HandshakeRetryTime     time.Duration
+	SyncedBlockDelta       uint64
+	SyncedPingTime         time.Duration
 }
 
 // NewPeerConnectionOptions returns default initialized PeerConnectionOptions
 func NewPeerConnectionOptions() *PeerConnectionOptions {
 	return &PeerConnectionOptions{
-		Checkpoints:           make([]Checkpoint, 0),
-		LocalRPCTimeout:       localRPCTimeoutDefault,
-		RemoteRPCTimeout:      remoteRPCTimeoutDefault,
-		BlockRequestBatchSize: blockRequestBatchSizeDefault,
-		BlockRequestTimeout:   blockRequestTimeoutDefault,
-		HandshakeRetryTime:    handshakeRetryTimeDefault,
-		SyncedBlockDelta:      syncedBlockDeltaDefault,
-		SyncedPingTime:        syncedPingTimeDefault,
+		Checkpoints:            make([]Checkpoint, 0),
+		LocalRPCTimeout:        localRPCTimeoutDefault,
+		BlockApplicatorTimeout: blockApplicatorTimeoutDefault,
+		RemoteRPCTimeout:       remoteRPCTimeoutDefault,
+		BlockRequestBatchSize:  blockRequestBatchSizeDefault,
+		BlockRequestTimeout:    blockRequestTimeoutDefault,
+		HandshakeRetryTime:     handshakeRetryTimeDefault,
+		SyncedBlockDelta:       syncedBlockDeltaDefault,
+		SyncedPingTime:         syncedPingTimeDefault,
 	}
 }

--- a/internal/p2p/block_applicator.go
+++ b/internal/p2p/block_applicator.go
@@ -29,12 +29,6 @@ type blockApplicationStatus struct {
 	err   error
 }
 
-// BlockError contains a block topology and an error for an error when pushing a specific block
-type BlockError struct {
-	topology koinos.BlockTopology
-	err      error
-}
-
 // BlockApplicator manages block application to avoid duplicate application and premature application
 type BlockApplicator struct {
 	rpc  rpc.LocalRPC

--- a/internal/p2p/block_applicator.go
+++ b/internal/p2p/block_applicator.go
@@ -174,10 +174,6 @@ func (b *BlockApplicator) requestApplication(ctx context.Context, block *protoco
 	}()
 }
 
-func (b *BlockApplicator) handleBlockStatus(ctx context.Context, status *blockApplicationStatus) {
-
-}
-
 func (b *BlockApplicator) handleNewBlock(ctx context.Context, entry *blockEntry) {
 	var err error
 

--- a/internal/p2p/connection_manager.go
+++ b/internal/p2p/connection_manager.go
@@ -43,9 +43,10 @@ type ConnectionManager struct {
 	server *gorpc.Server
 	client *gorpc.Client
 
-	localRPC    rpc.LocalRPC
-	peerOpts    *options.PeerConnectionOptions
-	libProvider LastIrreversibleBlockProvider
+	localRPC        rpc.LocalRPC
+	peerOpts        *options.PeerConnectionOptions
+	libProvider     LastIrreversibleBlockProvider
+	blockApplicator *BlockApplicator
 
 	initialPeers   map[peer.ID]peer.AddrInfo
 	connectedPeers map[peer.ID]*peerConnectionContext
@@ -66,7 +67,8 @@ func NewConnectionManager(
 	initialPeers []string,
 	peerErrorChan chan<- PeerError,
 	gossipVoteChan chan<- GossipVote,
-	signalPeerDisconnectChan chan<- peer.ID) *ConnectionManager {
+	signalPeerDisconnectChan chan<- peer.ID,
+	blockApplicator *BlockApplicator) *ConnectionManager {
 
 	connectionManager := ConnectionManager{
 		host:                     host,
@@ -75,6 +77,7 @@ func NewConnectionManager(
 		localRPC:                 localRPC,
 		peerOpts:                 peerOpts,
 		libProvider:              libProvider,
+		blockApplicator:          blockApplicator,
 		initialPeers:             make(map[peer.ID]peer.AddrInfo),
 		connectedPeers:           make(map[peer.ID]*peerConnectionContext),
 		peerConnectedChan:        make(chan connectionMessage),
@@ -152,6 +155,7 @@ func (c *ConnectionManager) handleConnected(ctx context.Context, msg connectionM
 				c.peerErrorChan,
 				c.gossipVoteChan,
 				c.peerOpts,
+				c.blockApplicator,
 			),
 			cancel: cancel,
 		}

--- a/internal/p2p/peer_connection.go
+++ b/internal/p2p/peer_connection.go
@@ -15,6 +15,14 @@ import (
 	"github.com/multiformats/go-multihash"
 )
 
+func max(x, y uint64) uint64 {
+	if x > y {
+		return x
+	}
+
+	return y
+}
+
 type signalRequestBlocks struct{}
 
 // PeerConnection handles the sync portion of a connection to a peer
@@ -23,14 +31,17 @@ type PeerConnection struct {
 	isSynced   bool
 	gossipVote bool
 	opts       *options.PeerConnectionOptions
+	//lastBlockPushed uint64
 
 	requestBlockChan chan signalRequestBlocks
+	blockErrorChan   chan *BlockError
 
-	libProvider    LastIrreversibleBlockProvider
-	localRPC       rpc.LocalRPC
-	peerRPC        rpc.RemoteRPC
-	peerErrorChan  chan<- PeerError
-	gossipVoteChan chan<- GossipVote
+	libProvider     LastIrreversibleBlockProvider
+	localRPC        rpc.LocalRPC
+	peerRPC         rpc.RemoteRPC
+	blockApplicator *BlockApplicator
+	peerErrorChan   chan<- PeerError
+	gossipVoteChan  chan<- GossipVote
 }
 
 func (p *PeerConnection) requestBlocks() {
@@ -152,21 +163,24 @@ func (p *PeerConnection) handleRequestBlocks(ctx context.Context) error {
 
 	// Apply blocks to local node
 	for i := range blocks {
-		rpcContext, cancelApplyBlock := context.WithTimeout(ctx, p.opts.LocalRPCTimeout)
+		applicatorContext, cancelApplyBlock := context.WithTimeout(ctx, p.opts.BlockApplicatorTimeout)
 		defer cancelApplyBlock()
-		_, err = p.localRPC.ApplyBlock(rpcContext, &blocks[i])
+
+		err = p.blockApplicator.ApplyBlock(applicatorContext, &blocks[i])
+
 		if err != nil {
 			// If it was a local RPC timeout, do not wrap it
 			if errors.Is(err, p2perrors.ErrLocalRPCTimeout) {
 				return err
 			}
 
-			return fmt.Errorf("%w: %s", p2perrors.ErrBlockApplication, err.Error())
+			// If we are applying a now irreversible block, it is probably we synced further with another peer,
+			// just keep applying blocks until we are caught up or we encounter a different error.
+			if errors.Is(err, p2perrors.ErrBlockIrreversibility) {
+				continue
+			}
 		}
 	}
-
-	// We will consider ourselves as syncing if we have more than 5 blocks to sync
-	p.isSynced = peerHeadHeight-blocks[len(blocks)-1].Header.Height < p.opts.SyncedBlockDelta
 
 	return nil
 }
@@ -240,16 +254,27 @@ func (p *PeerConnection) Start(ctx context.Context) {
 }
 
 // NewPeerConnection creates a PeerConnection
-func NewPeerConnection(id peer.ID, libProvider LastIrreversibleBlockProvider, localRPC rpc.LocalRPC, peerRPC rpc.RemoteRPC, peerErrorChan chan<- PeerError, gossipVoteChan chan<- GossipVote, opts *options.PeerConnectionOptions) *PeerConnection {
+func NewPeerConnection(
+	id peer.ID,
+	libProvider LastIrreversibleBlockProvider,
+	localRPC rpc.LocalRPC,
+	peerRPC rpc.RemoteRPC,
+	peerErrorChan chan<- PeerError,
+	gossipVoteChan chan<- GossipVote,
+	opts *options.PeerConnectionOptions,
+	blockApplicator *BlockApplicator) *PeerConnection {
 	return &PeerConnection{
-		id:               id,
-		isSynced:         false,
-		gossipVote:       false,
-		opts:             opts,
+		id:         id,
+		isSynced:   false,
+		gossipVote: false,
+		opts:       opts,
+		//lastBlockPushed:  0,
 		requestBlockChan: make(chan signalRequestBlocks),
+		blockErrorChan:   make(chan *BlockError),
 		libProvider:      libProvider,
 		localRPC:         localRPC,
 		peerRPC:          peerRPC,
+		blockApplicator:  blockApplicator,
 		peerErrorChan:    peerErrorChan,
 		gossipVoteChan:   gossipVoteChan,
 	}

--- a/internal/p2p/peer_connection.go
+++ b/internal/p2p/peer_connection.go
@@ -15,14 +15,6 @@ import (
 	"github.com/multiformats/go-multihash"
 )
 
-func max(x, y uint64) uint64 {
-	if x > y {
-		return x
-	}
-
-	return y
-}
-
 type signalRequestBlocks struct{}
 
 // PeerConnection handles the sync portion of a connection to a peer

--- a/internal/p2p/peer_connection.go
+++ b/internal/p2p/peer_connection.go
@@ -23,10 +23,8 @@ type PeerConnection struct {
 	isSynced   bool
 	gossipVote bool
 	opts       *options.PeerConnectionOptions
-	//lastBlockPushed uint64
 
 	requestBlockChan chan signalRequestBlocks
-	blockErrorChan   chan *BlockError
 
 	libProvider     LastIrreversibleBlockProvider
 	localRPC        rpc.LocalRPC
@@ -260,9 +258,7 @@ func NewPeerConnection(
 		isSynced:   false,
 		gossipVote: false,
 		opts:       opts,
-		//lastBlockPushed:  0,
 		requestBlockChan: make(chan signalRequestBlocks),
-		blockErrorChan:   make(chan *BlockError),
 		libProvider:      libProvider,
 		localRPC:         localRPC,
 		peerRPC:          peerRPC,


### PR DESCRIPTION
Resolves #205 
Resolves #217

## Brief description
Connects peer connection to the block applicator to prevent out of order, duplicate, and irreversible block application. This significantly reduces error messages and increases peer connection stability during sync.

## Checklist

- [X] I have built this pull request locally
- [X] I have ran the unit tests locally
- [X] I have manually tested this pull request
- [X] I have reviewed my pull request
- [X] I have added any relevant tests

## Demonstration

```
2022-08-25 10:28:02.982769 (p2p.Koinos) [p2p/peer_connection.go:144] <info>: Requesting blocks 1879-2879 from peer QmcGiTpSm6YrmYo3rWoqrCPez2aJY4VdraBQsGsZKwFRuG
2022-08-25 10:28:02.996044 (p2p.Koinos) [p2p/peer_connection.go:144] <info>: Requesting blocks 1879-2879 from peer QmbU6XyuGNiWk613bxqGdiGki11nZxa7weoBAdBp9cQoxB
2022-08-25 10:28:03.279048 (p2p.Koinos) [p2p/peer_connection.go:144] <info>: Requesting blocks 1879-2879 from peer QmbgUbBpYpG56deCGBXZfga1XzrHyZe8LMHBGQKKtFxx3E
2022-08-25 10:28:03.799799 (p2p.Koinos) [p2p/peer_connection.go:144] <info>: Requesting blocks 1880-2880 from peer QmV46fHfJ5K92Hcr5QG7Nyqe5u2A1AGVuSA5GbBTtABsS3
2022-08-25 10:28:03.801658 (p2p.Koinos) [p2p/peer_connection.go:144] <info>: Requesting blocks 1880-2880 from peer Qmbhs9xFdXb8qcLWUMRDKavPa56rrkqnD1hiyX5DLRjwX3
2022-08-25 10:28:03.807447 (p2p.Koinos) [p2p/peer_connection.go:144] <info>: Requesting blocks 1880-2880 from peer QmNNGc6MSTRQdp69sqTqSwXbyW4PcuQH4XzLhbugfvKKe9
2022-08-25 10:28:03.807872 (p2p.Koinos) [p2p/peer_connection.go:144] <info>: Requesting blocks 1880-2880 from peer QmZExW5SD9rfW26wGk3xnzxbsjxdYqK2GTMbygQzamRyxe
2022-08-25 10:28:03.883283 (p2p.Koinos) [p2p/peer_connection.go:144] <info>: Requesting blocks 1880-2880 from peer QmNfPGa94MfFxNbtzmzuKDCRkTXtNDhdNN6en7qseRMCuv
2022-08-25 10:28:39.711093 (p2p.Koinos) [koinos-mq-golang@v0.0.0-20220307194511-07a03f6f75f0/client.go:271] <warn>: RPC error: context deadline exceeded
2022-08-25 10:28:39.711213 (p2p.Koinos) [koinos-mq-golang@v0.0.0-20220307194511-07a03f6f75f0/client.go:272] <warn>: Trying again in 1 seconds
2022-08-25 10:29:01.885607 (p2p.Koinos) [node/node.go:351] <info>: My address:
2022-08-25 10:29:01.886578 (p2p.Koinos) [node/node.go:352] <info>:  - /ip4/10.0.0.66/tcp/8888/p2p/QmXZ6nk3iXYgJ1BH6t2zhG8H6vHmmiQ8Vk1ogoEYAR12C9
2022-08-25 10:29:01.886614 (p2p.Koinos) [node/node.go:353] <info>: Connected peers:
2022-08-25 10:29:01.886641 (p2p.Koinos) [node/node.go:355] <info>:  - /ip4/23.88.37.230/tcp/8888/p2p/QmV46fHfJ5K92Hcr5QG7Nyqe5u2A1AGVuSA5GbBTtABsS3
2022-08-25 10:29:01.886661 (p2p.Koinos) [node/node.go:355] <info>:  - /ip4/144.91.72.52/tcp/8888/p2p/Qmbhs9xFdXb8qcLWUMRDKavPa56rrkqnD1hiyX5DLRjwX3
2022-08-25 10:29:01.886680 (p2p.Koinos) [node/node.go:355] <info>:  - /ip4/144.76.219.133/tcp/8888/p2p/QmZExW5SD9rfW26wGk3xnzxbsjxdYqK2GTMbygQzamRyxe
2022-08-25 10:29:01.886697 (p2p.Koinos) [node/node.go:355] <info>:  - /ip4/194.13.80.81/tcp/8888/p2p/QmNNGc6MSTRQdp69sqTqSwXbyW4PcuQH4XzLhbugfvKKe9
2022-08-25 10:29:01.886715 (p2p.Koinos) [node/node.go:355] <info>:  - /ip4/118.69.194.69/tcp/8888/p2p/QmNfPGa94MfFxNbtzmzuKDCRkTXtNDhdNN6en7qseRMCuv
2022-08-25 10:29:01.887673 (p2p.Koinos) [node/node.go:355] <info>:  - /ip4/139.144.17.121/tcp/8888/p2p/QmcGiTpSm6YrmYo3rWoqrCPez2aJY4VdraBQsGsZKwFRuG
2022-08-25 10:29:01.887726 (p2p.Koinos) [node/node.go:355] <info>:  - /ip4/139.144.17.130/tcp/8888/p2p/QmbU6XyuGNiWk613bxqGdiGki11nZxa7weoBAdBp9cQoxB
2022-08-25 10:29:01.887746 (p2p.Koinos) [node/node.go:355] <info>:  - /ip4/45.79.175.16/tcp/8888/p2p/QmbgUbBpYpG56deCGBXZfga1XzrHyZe8LMHBGQKKtFxx3E
2022-08-25 10:29:07.790186 (p2p.Koinos) [p2p/peer_connection.go:144] <info>: Requesting blocks 2818-3818 from peer QmcGiTpSm6YrmYo3rWoqrCPez2aJY4VdraBQsGsZKwFRuG
2022-08-25 10:29:07.808369 (p2p.Koinos) [p2p/peer_connection.go:144] <info>: Requesting blocks 2818-3818 from peer QmbU6XyuGNiWk613bxqGdiGki11nZxa7weoBAdBp9cQoxB
2022-08-25 10:29:08.548194 (p2p.Koinos) [p2p/peer_connection.go:144] <info>: Requesting blocks 2819-3819 from peer QmbgUbBpYpG56deCGBXZfga1XzrHyZe8LMHBGQKKtFxx3E
2022-08-25 10:29:08.827970 (p2p.Koinos) [p2p/peer_connection.go:144] <info>: Requesting blocks 2820-3820 from peer QmV46fHfJ5K92Hcr5QG7Nyqe5u2A1AGVuSA5GbBTtABsS3
2022-08-25 10:29:08.829225 (p2p.Koinos) [p2p/peer_connection.go:144] <info>: Requesting blocks 2820-3820 from peer Qmbhs9xFdXb8qcLWUMRDKavPa56rrkqnD1hiyX5DLRjwX3
2022-08-25 10:29:08.830819 (p2p.Koinos) [p2p/peer_connection.go:144] <info>: Requesting blocks 2820-3820 from peer QmNNGc6MSTRQdp69sqTqSwXbyW4PcuQH4XzLhbugfvKKe9
2022-08-25 10:29:08.832233 (p2p.Koinos) [p2p/peer_connection.go:144] <info>: Requesting blocks 2820-3820 from peer QmZExW5SD9rfW26wGk3xnzxbsjxdYqK2GTMbygQzamRyxe
2022-08-25 10:29:08.869368 (p2p.Koinos) [p2p/peer_connection.go:144] <info>: Requesting blocks 2820-3820 from peer QmNfPGa94MfFxNbtzmzuKDCRkTXtNDhdNN6en7qseRMCuv
```
