### PR TITLE
Detect and handle fork bombs

### DIFF
--- a/internal/options/error_handler_options.go
+++ b/internal/options/error_handler_options.go
@@ -25,6 +25,7 @@ const (
 	localRPCTimeoutErrorScoreDefault         = 0
 	peerRPCTimeoutErrorScoreDefault          = 1000
 	processRequestTimeoutErrorScoreDefault   = 0
+	forkBombErrorScoreDefault                = 200000
 	unknownErrorScoreDefault                 = blockApplicationErrorScoreDefault
 )
 
@@ -49,6 +50,7 @@ type PeerErrorHandlerOptions struct {
 	LocalRPCTimeoutErrorScore         uint64
 	PeerRPCTimeoutErrorScore          uint64
 	ProcessRequestTimeoutErrorScore   uint64
+	ForkBombErrorScore                uint64
 	UnknownErrorScore                 uint64
 }
 
@@ -73,6 +75,7 @@ func NewPeerErrorHandlerOptions() *PeerErrorHandlerOptions {
 		LocalRPCTimeoutErrorScore:         localRPCTimeoutErrorScoreDefault,
 		PeerRPCTimeoutErrorScore:          peerRPCTimeoutErrorScoreDefault,
 		ProcessRequestTimeoutErrorScore:   processRequestTimeoutErrorScoreDefault,
+		ForkBombErrorScore:                forkBombErrorScoreDefault,
 		UnknownErrorScore:                 unknownErrorScoreDefault,
 	}
 }

--- a/internal/p2p/block_applicator_test.go
+++ b/internal/p2p/block_applicator_test.go
@@ -237,7 +237,7 @@ func TestBlockApplicatorLimits(t *testing.T) {
 			Id: []byte{byte(i)},
 			Header: &protocol.BlockHeader{
 				Height:   1,
-				Previous: []byte{0},
+				Previous: []byte{byte(i)},
 			},
 		})
 

--- a/internal/p2p/fork_watchdog.go
+++ b/internal/p2p/fork_watchdog.go
@@ -1,6 +1,7 @@
 package p2p
 
 import (
+	"sort"
 	"sync"
 
 	"github.com/koinos/koinos-p2p/internal/p2perrors"
@@ -55,5 +56,21 @@ func (f *ForkWatchdog) Purge(lib uint64) {
 	f.mutex.Lock()
 	defer f.mutex.Unlock()
 
-	delete(f.forkTracker, lib)
+	heights := make([]uint64, 0, len(f.forkTracker))
+
+	for h := range f.forkTracker {
+		heights = append(heights, h)
+	}
+
+	sort.Slice(heights, func(i, j int) bool {
+		return heights[i] < heights[j]
+	})
+
+	for _, h := range heights {
+		if h <= lib {
+			delete(f.forkTracker, h)
+		} else {
+			break
+		}
+	}
 }

--- a/internal/p2p/fork_watchdog.go
+++ b/internal/p2p/fork_watchdog.go
@@ -1,0 +1,50 @@
+package p2p
+
+import (
+	"github.com/koinos/koinos-p2p/internal/p2perrors"
+	"github.com/koinos/koinos-proto-golang/koinos/protocol"
+)
+
+type pairKey struct {
+	Signer string
+	Parent string
+}
+
+type ForkWatchdog struct {
+	forkTracker map[uint64]map[pairKey]map[string]void
+}
+
+func NewForkWatchdog() *ForkWatchdog {
+	return &ForkWatchdog{
+		forkTracker: make(map[uint64]map[pairKey]map[string]void),
+	}
+}
+
+// Add a block to the fork watchdog
+func (f *ForkWatchdog) Add(block *protocol.Block) error {
+	pair := pairKey{
+		Signer: string(block.Header.Signer),
+		Parent: string(block.Header.Previous),
+	}
+
+	if _, ok := f.forkTracker[block.Header.Height]; !ok {
+		f.forkTracker[block.Header.Height] = make(map[pairKey]map[string]void)
+	}
+
+	if _, ok := f.forkTracker[block.Header.Height][pair]; !ok {
+		f.forkTracker[block.Header.Height][pair] = make(map[string]void)
+	}
+
+	f.forkTracker[block.Header.Height][pair][string(block.Id)] = void{}
+
+	if len(f.forkTracker[block.Header.Height][pair]) > 3 {
+		return p2perrors.ErrForkBomb
+	}
+
+	return nil
+}
+
+// Purge a set of fork records from fork watchdog
+func (f *ForkWatchdog) Purge(lib uint64) {
+	delete(f.forkTracker, lib)
+}

--- a/internal/p2p/fork_watchdog.go
+++ b/internal/p2p/fork_watchdog.go
@@ -1,6 +1,8 @@
 package p2p
 
 import (
+	"sync"
+
 	"github.com/koinos/koinos-p2p/internal/p2perrors"
 	"github.com/koinos/koinos-proto-golang/koinos/protocol"
 )
@@ -12,6 +14,7 @@ type pairKey struct {
 
 type ForkWatchdog struct {
 	forkTracker map[uint64]map[pairKey]map[string]void
+	mutex       sync.Mutex
 }
 
 func NewForkWatchdog() *ForkWatchdog {
@@ -22,6 +25,9 @@ func NewForkWatchdog() *ForkWatchdog {
 
 // Add a block to the fork watchdog
 func (f *ForkWatchdog) Add(block *protocol.Block) error {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
 	pair := pairKey{
 		Signer: string(block.Header.Signer),
 		Parent: string(block.Header.Previous),
@@ -46,5 +52,8 @@ func (f *ForkWatchdog) Add(block *protocol.Block) error {
 
 // Purge a set of fork records from fork watchdog
 func (f *ForkWatchdog) Purge(lib uint64) {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
 	delete(f.forkTracker, lib)
 }

--- a/internal/p2p/fork_watchdog_test.go
+++ b/internal/p2p/fork_watchdog_test.go
@@ -1,0 +1,87 @@
+package p2p
+
+import (
+	"testing"
+
+	"github.com/koinos/koinos-p2p/internal/p2perrors"
+	"github.com/koinos/koinos-proto-golang/koinos/protocol"
+)
+
+func TestForkWatchdog(t *testing.T) {
+	fw := NewForkWatchdog()
+
+	block := &protocol.Block{
+		Id: []byte{0x01, 0x02, 0x03, 0x04},
+		Header: &protocol.BlockHeader{
+			Signer:   []byte{0x01, 0x01, 0x01},
+			Height:   1,
+			Previous: []byte{0x01},
+		},
+	}
+
+	err := fw.Add(block)
+	if err != nil {
+		t.Error(err)
+	}
+
+	block.Id = []byte{0x01, 0x02, 0x03, 0x05}
+
+	err = fw.Add(block)
+	if err != nil {
+		t.Error(err)
+	}
+
+	block.Id = []byte{0x01, 0x02, 0x03, 0x06}
+
+	err = fw.Add(block)
+	if err != nil {
+		t.Error(err)
+	}
+
+	block.Id = []byte{0x01, 0x02, 0x03, 0x07}
+
+	err = fw.Add(block)
+	if err != p2perrors.ErrForkBomb {
+		t.Error("should have detected fork bomb")
+	}
+
+	fw.Purge(block.Header.Height)
+
+	block.Id = []byte{0x01, 0x02, 0x03, 0x04}
+
+	err = fw.Add(block)
+	if err != nil {
+		t.Error(err)
+	}
+
+	block.Id = []byte{0x01, 0x02, 0x03, 0x05}
+
+	err = fw.Add(block)
+	if err != nil {
+		t.Error(err)
+	}
+
+	block.Id = []byte{0x01, 0x02, 0x03, 0x06}
+
+	err = fw.Add(block)
+	if err != nil {
+		t.Error(err)
+	}
+
+	block.Id = []byte{0x01, 0x02, 0x03, 0x07}
+
+	block.Header.Previous = []byte{0x02}
+
+	// Different parent block should not trigger fork bomb
+	err = fw.Add(block)
+	if err != nil {
+		t.Error(err)
+	}
+
+	block.Header.Previous = []byte{0x01}
+
+	err = fw.Add(block)
+	if err != p2perrors.ErrForkBomb {
+		t.Error("should have detected fork bomb")
+	}
+}

--- a/internal/p2p/fork_watchdog_test.go
+++ b/internal/p2p/fork_watchdog_test.go
@@ -84,4 +84,17 @@ func TestForkWatchdog(t *testing.T) {
 	if err != p2perrors.ErrForkBomb {
 		t.Error("should have detected fork bomb")
 	}
+
+	block.Header.Height = 2
+	err = fw.Add(block)
+	if err != nil {
+		t.Error(err)
+	}
+
+	fw.Purge(2)
+	block.Header.Height = 1
+	err = fw.Add(block)
+	if err != nil {
+		t.Error(err)
+	}
 }

--- a/internal/p2p/peer_connection.go
+++ b/internal/p2p/peer_connection.go
@@ -164,6 +164,10 @@ func (p *PeerConnection) handleRequestBlocks(ctx context.Context) error {
 				return err
 			}
 
+			if errors.Is(err, p2perrors.ErrForkBomb) {
+				return err
+			}
+
 			// If we are applying a now irreversible block, it is probably we synced further with another peer,
 			// just keep applying blocks until we are caught up or we encounter a different error.
 			if errors.Is(err, p2perrors.ErrBlockIrreversibility) {

--- a/internal/p2perrors/errors.go
+++ b/internal/p2perrors/errors.go
@@ -52,4 +52,7 @@ var (
 
 	// ErrMaxPendingBlocks represents when too many blocks are pending application
 	ErrMaxPendingBlocks = errors.New("max blocks are pending application")
+
+	// ErrForkBomb represents when too many forks from a producer is detected
+	ErrForkBomb = errors.New("unacceptable number of forks on the same parent for a single producer")
 )


### PR DESCRIPTION
Resolves #221.

## Brief description
Detect and handle for bombs. When a user creates more than 3 blocks off the same parent we consider that a fork bomb and spank you off the network.

## Checklist

- [x] I have built this pull request locally
- [x] I have ran the unit tests locally
- [ ] I have manually tested this pull request
- [x] I have reviewed my pull request
- [x] I have added any relevant tests

## Demonstration
```console
Running tool: /usr/local/bin/go test -timeout 30s -run ^TestForkWatchdog$ github.com/koinos/koinos-p2p/internal/p2p

ok  	github.com/koinos/koinos-p2p/internal/p2p	0.172s
```
