### PR TITLE
Make the applicator error channel bufferred

### DIFF
--- a/internal/p2p/block_applicator.go
+++ b/internal/p2p/block_applicator.go
@@ -163,7 +163,7 @@ func (b *BlockApplicator) removeEntry(ctx context.Context, id string, err error)
 
 func (b *BlockApplicator) requestApplication(ctx context.Context, block *protocol.Block) {
 	go func() {
-		errChan := make(chan error)
+		errChan := make(chan error, 1)
 
 		b.applyBlockChan <- &blockApplicationRequest{
 			block:   block,


### PR DESCRIPTION
## Brief description

Make the error channel a buffered channel so that if the block application times out, the calling go routine does not get blocked.

## Checklist

- [X] I have built this pull request locally
- [X] I have ran the unit tests locally
- [X] I have manually tested this pull request
- [X] I have reviewed my pull request
- [ ] I have added any relevant tests

## Demonstration
