### PR TITLE
Restore check for peer de-sync

### DIFF
--- a/internal/p2p/peer_connection.go
+++ b/internal/p2p/peer_connection.go
@@ -178,6 +178,9 @@ func (p *PeerConnection) handleRequestBlocks(ctx context.Context) error {
 		}
 	}
 
+	// We will consider ourselves as syncing if we have more than 5 blocks to sync
+	p.isSynced = peerHeadHeight-blocks[len(blocks)-1].Header.Height < p.opts.SyncedBlockDelta
+
 	return nil
 }
 


### PR DESCRIPTION
## Brief description

Restores sync check that was erroneously removed

## Checklist

- [X] I have built this pull request locally
- [X] I have ran the unit tests locally
- [X] I have manually tested this pull request
- [X] I have reviewed my pull request
- [X] I have added any relevant tests

## Demonstration

