### PR TITLE
Increase the batch block request timeout

### DIFF
--- a/internal/options/peer_connection_options.go
+++ b/internal/options/peer_connection_options.go
@@ -17,7 +17,7 @@ const (
 	applicatorTimeoutDefault     = localRPCTimeoutDefault * 2
 	remoteRPCTimeoutDefault      = time.Second * 6
 	blockRequestBatchSizeDefault = 1000
-	blockRequestTimeoutDefault   = time.Second * 6
+	blockRequestTimeoutDefault   = time.Second * time.Duration(blockRequestBatchSizeDefault * 0.3) // Roughly calculated considering 30Mbps minimum upload speed and 1MB blocks
 	handshakeRetryTimeDefault    = time.Second * 6
 	syncedBlockDeltaDefault      = 5
 	syncedPingTimeDefault        = time.Second * 10


### PR DESCRIPTION
## Brief description
increases the batch block request timeout to 5m for 1000 batch with maximum block size.

## Checklist

- [ ] I have built this pull request locally
- [ ] I have ran the unit tests locally
- [ ] I have manually tested this pull request
- [x] I have reviewed my pull request
- [ ] I have added any relevant tests

