### PR TITLE
Error score reconnect threshold

### DIFF
--- a/internal/options/error_handler_options.go
+++ b/internal/options/error_handler_options.go
@@ -5,8 +5,9 @@ import (
 )
 
 const (
-	errorScoreDecayHalflifeDefault = time.Minute * 10
-	errorScoreThresholdDefault     = 100000
+	errorScoreDecayHalflifeDefault      = time.Minute * 10
+	errorScoreThresholdDefault          = 100000
+	errorScoreReconnectThresholdDefault = errorScoreThresholdDefault / 2
 
 	deserializationErrorScoreDefault         = 5000
 	serializationErrorScoreDefault           = 0
@@ -30,8 +31,9 @@ const (
 
 // PeerErrorHandlerOptions are options for PeerErrorHandler
 type PeerErrorHandlerOptions struct {
-	ErrorScoreDecayHalflife time.Duration
-	ErrorScoreThreshold     uint64
+	ErrorScoreDecayHalflife      time.Duration
+	ErrorScoreThreshold          uint64
+	ErrorScoreReconnectThreshold uint64
 
 	DeserializationErrorScore         uint64
 	SerializationErrorScore           uint64
@@ -58,6 +60,7 @@ func NewPeerErrorHandlerOptions() *PeerErrorHandlerOptions {
 	return &PeerErrorHandlerOptions{
 		ErrorScoreDecayHalflife:           errorScoreDecayHalflifeDefault,
 		ErrorScoreThreshold:               errorScoreThresholdDefault,
+		ErrorScoreReconnectThreshold:      errorScoreReconnectThresholdDefault,
 		DeserializationErrorScore:         deserializationErrorScoreDefault,
 		SerializationErrorScore:           serializationErrorScoreDefault,
 		BlockIrreversibilityErrorScore:    blockIrreversibilityErrorScoreDefault,

--- a/internal/p2p/error_handler.go
+++ b/internal/p2p/error_handler.go
@@ -75,7 +75,7 @@ func (p *PeerErrorHandler) CanConnectAddr(ctx context.Context, addr ma.Multiaddr
 func (p *PeerErrorHandler) handleCanConnect(addr ma.Multiaddr) bool {
 	if record, ok := p.errorScores[ma.Split(addr)[0].String()]; ok {
 		p.decayErrorScore(record)
-		return record.score < p.opts.ErrorScoreThreshold
+		return record.score < p.opts.ErrorScoreReconnectThreshold
 	}
 
 	return true

--- a/internal/p2p/error_handler_test.go
+++ b/internal/p2p/error_handler_test.go
@@ -31,6 +31,7 @@ func TestErrorHandler(t *testing.T) {
 
 	opts.BlockApplicationErrorScore = 10
 	opts.ErrorScoreThreshold = 100
+	opts.ErrorScoreReconnectThreshold = 50
 	opts.ErrorScoreDecayHalflife = time.Second * 2
 
 	peerStore := &testProvider{
@@ -64,7 +65,7 @@ func TestErrorHandler(t *testing.T) {
 		t.Errorf("Expected failed connection to peerA")
 	}
 
-	time.Sleep(time.Millisecond * 500)
+	time.Sleep(time.Millisecond * 2500)
 
 	if !errorHandler.CanConnect(ctx, "peerA") {
 		t.Errorf("Expected successful connection to peerA")


### PR DESCRIPTION
Resolves #243.

## Brief description
An error score must decay to half the disconnect threshold before a reconnection attempt is made.

## Checklist

- [x] I have built this pull request locally
- [x] I have ran the unit tests locally
- [ ] I have manually tested this pull request
- [x] I have reviewed my pull request
- [x] I have added any relevant tests

## Demonstration
```console
=== RUN   TestErrorHandler
--- PASS: TestErrorHandler (3.50s)
```
