### PR TITLE
Track highest block height instead of just head

### DIFF
--- a/internal/options/error_handler_options.go
+++ b/internal/options/error_handler_options.go
@@ -26,6 +26,7 @@ const (
 	peerRPCTimeoutErrorScoreDefault          = 1000
 	processRequestTimeoutErrorScoreDefault   = 0
 	forkBombErrorScoreDefault                = 200000
+	maxHeightErrorScoreDefault               = blockApplicationErrorScoreDefault
 	unknownErrorScoreDefault                 = blockApplicationErrorScoreDefault
 )
 
@@ -52,6 +53,7 @@ type PeerErrorHandlerOptions struct {
 	PeerRPCTimeoutErrorScore          uint64
 	ProcessRequestTimeoutErrorScore   uint64
 	ForkBombErrorScore                uint64
+	MaxHeightErrorScore               uint64
 	UnknownErrorScore                 uint64
 }
 
@@ -78,6 +80,7 @@ func NewPeerErrorHandlerOptions() *PeerErrorHandlerOptions {
 		PeerRPCTimeoutErrorScore:          peerRPCTimeoutErrorScoreDefault,
 		ProcessRequestTimeoutErrorScore:   processRequestTimeoutErrorScoreDefault,
 		ForkBombErrorScore:                forkBombErrorScoreDefault,
+		MaxHeightErrorScore:               maxHeightErrorScoreDefault,
 		UnknownErrorScore:                 unknownErrorScoreDefault,
 	}
 }

--- a/internal/p2p/applicator.go
+++ b/internal/p2p/applicator.go
@@ -3,7 +3,6 @@ package p2p
 import (
 	"context"
 	"errors"
-	"fmt"
 	"sync/atomic"
 	"time"
 
@@ -231,7 +230,7 @@ func (b *Applicator) handleNewBlock(ctx context.Context, entry *blockEntry) {
 	var err error
 
 	if entry.block.Header.Height > b.highestBlock+b.opts.MaxHeightDelta {
-		err = fmt.Errorf("%w, block height exeeds applicator height delta", p2perrors.ErrBlockApplication)
+		err = p2perrors.ErrMaxHeight
 	} else if len(b.blocksById) >= int(b.opts.MaxPendingBlocks) {
 		err = p2perrors.ErrMaxPendingBlocks
 	} else if entry.block.Header.Height <= b.lib {

--- a/internal/p2p/applicator.go
+++ b/internal/p2p/applicator.go
@@ -3,13 +3,13 @@ package p2p
 import (
 	"context"
 	"errors"
+	"fmt"
 	"sync/atomic"
 	"time"
 
 	"github.com/koinos/koinos-p2p/internal/options"
 	"github.com/koinos/koinos-p2p/internal/p2perrors"
 	"github.com/koinos/koinos-p2p/internal/rpc"
-	"github.com/koinos/koinos-proto-golang/koinos"
 	"github.com/koinos/koinos-proto-golang/koinos/broadcast"
 	"github.com/koinos/koinos-proto-golang/koinos/protocol"
 )
@@ -38,9 +38,9 @@ type transactionApplicatorRequest struct {
 
 // Applicator manages block application to avoid duplicate application and premature application
 type Applicator struct {
-	rpc  rpc.LocalRPC
-	head *koinos.BlockTopology
-	lib  uint64
+	rpc          rpc.LocalRPC
+	highestBlock uint64
+	lib          uint64
 
 	forkWatchdog *ForkWatchdog
 
@@ -67,7 +67,7 @@ func NewApplicator(ctx context.Context, rpc rpc.LocalRPC, opts options.Applicato
 
 	return &Applicator{
 		rpc:                  rpc,
-		head:                 headInfo.HeadTopology,
+		highestBlock:         headInfo.HeadTopology.Height,
 		lib:                  headInfo.LastIrreversibleBlock,
 		forkWatchdog:         NewForkWatchdog(),
 		blocksById:           make(map[string]*blockEntry),
@@ -149,7 +149,7 @@ func (b *Applicator) addEntry(ctx context.Context, entry *blockEntry) {
 	}
 	b.blocksByHeight[height][id] = void{}
 
-	if entry.block.Header.Height <= b.head.Height+1 {
+	if entry.block.Header.Height <= b.highestBlock+1 {
 		b.requestApplication(ctx, entry.block)
 	}
 }
@@ -230,8 +230,8 @@ func (b *Applicator) requestApplication(ctx context.Context, block *protocol.Blo
 func (b *Applicator) handleNewBlock(ctx context.Context, entry *blockEntry) {
 	var err error
 
-	if entry.block.Header.Height > b.head.Height+b.opts.MaxHeightDelta {
-		err = p2perrors.ErrBlockApplication
+	if entry.block.Header.Height > b.highestBlock+b.opts.MaxHeightDelta {
+		err = fmt.Errorf("%w, block height exeeds applicator height delta", p2perrors.ErrBlockApplication)
 	} else if len(b.blocksById) >= int(b.opts.MaxPendingBlocks) {
 		err = p2perrors.ErrMaxPendingBlocks
 	} else if entry.block.Header.Height <= b.lib {
@@ -274,8 +274,9 @@ func (b *Applicator) handleForkHeads(ctx context.Context, forkHeads *broadcast.F
 }
 
 func (b *Applicator) handleBlockBroadcast(ctx context.Context, blockAccept *broadcast.BlockAccepted) {
-	if blockAccept.Head {
-		b.head = &koinos.BlockTopology{Id: blockAccept.Block.Id, Height: blockAccept.Block.Header.Height, Previous: blockAccept.Block.Header.Previous}
+	// It is not possible for a block with a new highest height to not be head, so this check is sufficient
+	if blockAccept.Block.Header.Height > b.highestBlock {
+		b.highestBlock = blockAccept.Block.Header.Height
 	}
 
 	if children, ok := b.blocksByPrevious[string(blockAccept.Block.Id)]; ok {

--- a/internal/p2p/applicator_test.go
+++ b/internal/p2p/applicator_test.go
@@ -311,7 +311,7 @@ func TestApplicatorLimits(t *testing.T) {
 	}
 
 	err = applicator.ApplyBlock(ctx, futureBlock)
-	if err != p2perrors.ErrBlockApplication {
+	if err != p2perrors.ErrMaxHeight {
 		t.Errorf("block2b - ErrBlockApplication expected but not returned, was: %v", err)
 	}
 

--- a/internal/p2p/error_handler.go
+++ b/internal/p2p/error_handler.go
@@ -122,6 +122,8 @@ func (p *PeerErrorHandler) getScoreForError(err error) uint64 {
 		return p.opts.BlockApplicationTimeoutErrorScore
 	case errors.Is(err, p2perrors.ErrMaxPendingBlocks):
 		return p.opts.MaxPendingBlocksErrorScore
+	case errors.Is(err, p2perrors.ErrMaxHeight):
+		return p.opts.MaxHeightErrorScore
 	case errors.Is(err, p2perrors.ErrDeserialization):
 		return p.opts.DeserializationErrorScore
 	case errors.Is(err, p2perrors.ErrBlockIrreversibility):

--- a/internal/p2perrors/errors.go
+++ b/internal/p2perrors/errors.go
@@ -55,4 +55,7 @@ var (
 
 	// ErrForkBomb represents when too many forks from a producer is detected
 	ErrForkBomb = errors.New("unacceptable number of forks on the same parent for a single producer")
+
+	// ErrMaxHeight represents when a block application is requested that has too high of a height
+	ErrMaxHeight = errors.New("block height exceeds max height")
 )


### PR DESCRIPTION
## Brief description

With the PoB Node Comparator, it is possible that the head block is not the highest block. If that happens and one of the blocks higher than head is built on, the block will get stuck in the applicator. This change allows that block to be applied and progress to be made.

## Checklist

- [X] I have built this pull request locally
- [X] I have ran the unit tests locally
- [X] I have manually tested this pull request
- [X] I have reviewed my pull request
- [ ] I have added any relevant tests

## Demonstration
