### PR TITLE
Store subscription locally to avoid nil pointer dereference

### DIFF
--- a/internal/p2p/gossip.go
+++ b/internal/p2p/gossip.go
@@ -134,9 +134,10 @@ func readMessages(ctx context.Context, ch chan<- []byte, sub *pubsub.Subscriptio
 		}
 
 		select {
-		case ch <- msg.Data:
 		case <-ctx.Done():
 			return
+		case ch <- msg.Data:
+
 		}
 	}
 }

--- a/internal/p2p/gossip.go
+++ b/internal/p2p/gossip.go
@@ -85,7 +85,7 @@ func (gm *GossipManager) Start(ctx context.Context, ch chan<- []byte) error {
 	subCtx, cancel := context.WithCancel(ctx)
 	gm.cancel = cancel
 
-	go gm.readMessages(subCtx, ch)
+	go readMessages(subCtx, ch, gm.sub, gm.topicName)
 
 	gm.Enabled = true
 
@@ -118,18 +118,18 @@ func (gm *GossipManager) PublishMessage(ctx context.Context, bytes []byte) bool 
 	return true
 }
 
-func (gm *GossipManager) readMessages(ctx context.Context, ch chan<- []byte) {
+func readMessages(ctx context.Context, ch chan<- []byte, sub *pubsub.Subscription, topicName string) {
 	//
-	// The purpose of this function is to move messages from each topic's gm.sub.Next()
+	// The purpose of this function is to move messages from each topic's sub.Next()
 	// and send them to a single channel.
 	//
 	// Note that libp2p has already used the callback passed to RegisterValidator()
 	// to validate blocks / transactions.
 	//
 	for {
-		msg, err := gm.sub.Next(ctx)
+		msg, err := sub.Next(ctx)
 		if err != nil && !errors.Is(context.DeadlineExceeded, err) {
-			log.Warnf("Error getting message for topic %s: %s", gm.topicName, err)
+			log.Warnf("Error getting message for topic %s: %s", topicName, err)
 			return
 		}
 


### PR DESCRIPTION
Possibly resolves #238

## Brief description

Do not change the subscription pointer out from under `readMessages`.

## Checklist

- [X] I have built this pull request locally
- [X] I have ran the unit tests locally
- [X] I have manually tested this pull request
- [X] I have reviewed my pull request
- [ ] I have added any relevant tests

## Demonstration
<!-- If applicable, attach screenshot or terminal output of working code -->
