### PR TITLE
Toggle gossip off when head block time is 30 seconds away

### DIFF
--- a/internal/p2p/gossip_toggle.go
+++ b/internal/p2p/gossip_toggle.go
@@ -68,7 +68,7 @@ func (g *GossipToggle) Start(ctx context.Context) {
 			g.headMutex.Unlock()
 
 			// We disable gossip when we are 1 minute behind the current time
-			if time.Since(t) <= time.Minute {
+			if time.Since(t) <= 30*time.Second {
 				if !g.enabled {
 					g.gossipEnabler.EnableGossip(ctx, true)
 					g.enabledMutex.Lock()


### PR DESCRIPTION
## Brief description
When you haven't applied a head block within the last 30 seconds, toggle gossip off.

## Checklist

- [x] I have built this pull request locally
- [x] I have ran the unit tests locally
- [ ] I have manually tested this pull request
- [x] I have reviewed my pull request
- [ ] I have added any relevant tests

