### PR TITLE
Removes the 10 seconds timeout when adding a txs to the applicator

### DIFF
--- a/internal/p2p/gossip.go
+++ b/internal/p2p/gossip.go
@@ -418,10 +418,7 @@ func (kg *KoinosGossip) applyTransaction(ctx context.Context, pid peer.ID, msg *
 		return fmt.Errorf("%w, gossiped transaction missing id", p2perrors.ErrDeserialization)
 	}
 
-	trxCtx, trxCancel := context.WithTimeout(ctx, time.Second*10)
-	defer trxCancel()
-
-	if err := kg.applicator.ApplyTransaction(trxCtx, transaction); err != nil {
+	if err := kg.applicator.ApplyTransaction(ctx, transaction); err != nil {
 		return fmt.Errorf("%w - %s, %v", p2perrors.ErrTransactionApplication, util.TransactionString(transaction), err.Error())
 	}
 


### PR DESCRIPTION
## Brief description
Removes 10 seconds timeout from transactions added to the applicator.

## Checklist

- [ ] I have built this pull request locally
- [ ] I have ran the unit tests locally
- [ ] I have manually tested this pull request
- [ ] I have reviewed my pull request
- [ ] I have added any relevant tests

