### PR TITLE
Assign chain ID mismatch naughty points if we cannot retrieve the pee…

### DIFF
--- a/cmd/koinos-p2p/main.go
+++ b/cmd/koinos-p2p/main.go
@@ -63,7 +63,7 @@ const (
 // Version display values
 const (
 	DisplayAppName = "Koinos P2P"
-	Version        = "v1.1.0"
+	Version        = "v1.1.1"
 )
 
 // Gets filled in by the linker

--- a/internal/p2p/connection_manager.go
+++ b/internal/p2p/connection_manager.go
@@ -166,7 +166,7 @@ func (c *ConnectionManager) handleConnected(ctx context.Context, msg connectionM
 	pid := msg.conn.RemotePeer()
 	s := fmt.Sprintf("%s/p2p/%s", msg.conn.RemoteMultiaddr(), pid)
 
-	log.Infof("Connected to peer: %s", s)
+	log.Debugf("Connected to peer: %s", s)
 
 	if _, ok := c.connectedPeers[pid]; !ok {
 		childCtx, cancel := context.WithCancel(ctx)
@@ -200,16 +200,16 @@ func (c *ConnectionManager) handleDisconnected(ctx context.Context, msg connecti
 	}
 
 	s := fmt.Sprintf("%s/p2p/%s", msg.conn.RemoteMultiaddr(), msg.conn.RemotePeer())
-	log.Infof("Disconnected from peer: %s", s)
+	log.Debugf("Disconnected from peer: %s", s)
 
 	if addr, ok := c.initialPeers[pid]; ok {
 		go func() {
 			sleepTimeSeconds := 1
 			for {
-				log.Infof("Attempting to connect to peer %v", addr.ID)
+				log.Infof("Attempting to connect to seed %v", addr.ID)
 				err := c.host.Connect(ctx, addr)
 				if err != nil {
-					log.Infof("Error connecting to peer %v: %s", addr.ID, err)
+					log.Infof("Error connecting to seed %v: %s", addr.ID, err)
 				} else {
 					return
 				}

--- a/internal/p2p/error_handler.go
+++ b/internal/p2p/error_handler.go
@@ -130,7 +130,9 @@ func (p *PeerErrorHandler) handleError(ctx context.Context, peerErr PeerError) {
 			}
 		}
 
-		log.Infof("Encountered peer error: %s, %s. Current error score: %v", peerErr.id, peerErr.err.Error(), p.errorScores[ipAddr].score)
+		if !errors.Is(peerErr.err, p2perrors.ErrChainIDMismatch) {
+			log.Infof("Encountered peer error: %s, %s. Current error score: %v", peerErr.id, peerErr.err.Error(), p.errorScores[ipAddr].score)
+		}
 
 		if p.errorScores[ipAddr].score >= p.opts.ErrorScoreThreshold {
 			go func() {

--- a/internal/p2p/peer_connection.go
+++ b/internal/p2p/peer_connection.go
@@ -50,7 +50,7 @@ func (p *PeerConnection) handshake(ctx context.Context) error {
 	defer cancelPeerGetChainID()
 	peerChainID, err := p.peerRPC.GetChainID(rpcContext)
 	if err != nil {
-		return err
+		return p2perrors.ErrChainIDMismatch
 	}
 
 	if !bytes.Equal(myChainID.ChainId, peerChainID) {


### PR DESCRIPTION
…r's chain id

## Brief description
Assign chain ID mismatch naughty points if we cannot retrieve the peer's chain id

## Checklist

- [ ] I have built this pull request locally
- [ ] I have ran the unit tests locally
- [ ] I have manually tested this pull request
- [ ] I have reviewed my pull request
- [ ] I have added any relevant tests

## Demonstration
<!-- If applicable, attach screenshot or terminal output of working code -->
