### PR TITLE
Add a flag to turn DHT local peer discovery, default the flag to false

### DIFF
--- a/cmd/koinos-p2p/main.go
+++ b/cmd/koinos-p2p/main.go
@@ -41,6 +41,7 @@ const (
 	instanceIDOption    = "instance-id"
 	jobsOption          = "jobs"
 	versionOption       = "version"
+	DHTRoutingOption    = "dht-routing"
 )
 
 const (
@@ -54,6 +55,7 @@ const (
 	logColorDefault      = true
 	logDatetimeDefault   = true
 	instanceIDDefault    = ""
+	DHTRoutingDefault    = false
 )
 
 const (
@@ -92,6 +94,7 @@ func main() {
 	instanceID := flag.StringP(instanceIDOption, "i", instanceIDDefault, "The instance ID to identify this node")
 	jobs := flag.IntP(jobsOption, "j", jobsDefault, "Number of RPC jobs to run")
 	version := flag.BoolP(versionOption, "v", false, "Print version and exit")
+	DHTRouting := flag.Bool(DHTRoutingOption, DHTRoutingDefault, "Disables DHT routing")
 
 	flag.Parse()
 
@@ -121,6 +124,7 @@ func main() {
 	*logDatetime = util.GetBoolOption(logDatetimeOption, logDatetimeDefault, *logDatetime, yamlConfig.P2P, yamlConfig.Global)
 	*instanceID = util.GetStringOption(instanceIDOption, util.GenerateBase58ID(5), *instanceID, yamlConfig.P2P, yamlConfig.Global)
 	*jobs = util.GetIntOption(jobsOption, jobsDefault, *jobs, yamlConfig.P2P, yamlConfig.Global)
+	*DHTRouting = util.GetBoolOption(DHTRoutingOption, DHTRoutingDefault, *DHTRouting, yamlConfig.P2P, yamlConfig.Global)
 
 	if len(*logDir) > 0 && !path.IsAbs(*logDir) {
 		*logDir = path.Join(util.GetAppDir(baseDir, appName), *logDir)
@@ -164,6 +168,9 @@ func main() {
 	}
 	if *forceGossip {
 		config.GossipToggleOptions.AlwaysEnable = true
+	}
+	if *DHTRouting {
+		config.NodeOptions.DHTRouting = true
 	}
 
 	for _, checkpoint := range *checkpoints {

--- a/cmd/koinos-p2p/main.go
+++ b/cmd/koinos-p2p/main.go
@@ -26,36 +26,36 @@ import (
 )
 
 const (
-	baseDirOption       = "basedir"
-	amqpOption          = "amqp"
-	listenOption        = "listen"
-	seedOption          = "seed"
-	peerOption          = "peer"
-	checkpointOption    = "checkpoint"
-	disableGossipOption = "disable-gossip"
-	forceGossipOption   = "force-gossip"
-	logLevelOption      = "log-level"
-	logDirOption        = "log-dir"
-	logColorOption      = "log-color"
-	logDatetimeOption   = "log-datetime"
-	instanceIDOption    = "instance-id"
-	jobsOption          = "jobs"
-	versionOption       = "version"
-	DHTRoutingOption    = "dht-routing"
+	baseDirOption           = "basedir"
+	amqpOption              = "amqp"
+	listenOption            = "listen"
+	seedOption              = "seed"
+	peerOption              = "peer"
+	checkpointOption        = "checkpoint"
+	disableGossipOption     = "disable-gossip"
+	forceGossipOption       = "force-gossip"
+	logLevelOption          = "log-level"
+	logDirOption            = "log-dir"
+	logColorOption          = "log-color"
+	logDatetimeOption       = "log-datetime"
+	instanceIDOption        = "instance-id"
+	jobsOption              = "jobs"
+	versionOption           = "version"
+	dhtLocalDiscoveryOption = "dht-local-discovery"
 )
 
 const (
-	baseDirDefault       = ".koinos"
-	amqpDefault          = "amqp://guest:guest@localhost:5672/"
-	listenDefault        = "/ip4/127.0.0.1/tcp/8888"
-	seedDefault          = ""
-	disableGossipDefault = false
-	forceGossipDefault   = false
-	logLevelDefault      = "info"
-	logColorDefault      = true
-	logDatetimeDefault   = true
-	instanceIDDefault    = ""
-	DHTRoutingDefault    = false
+	baseDirDefault           = ".koinos"
+	amqpDefault              = "amqp://guest:guest@localhost:5672/"
+	listenDefault            = "/ip4/127.0.0.1/tcp/8888"
+	seedDefault              = ""
+	disableGossipDefault     = false
+	forceGossipDefault       = false
+	logLevelDefault          = "info"
+	logColorDefault          = true
+	logDatetimeDefault       = true
+	instanceIDDefault        = ""
+	dhtLocalDiscoveryDefault = false
 )
 
 const (
@@ -94,7 +94,7 @@ func main() {
 	instanceID := flag.StringP(instanceIDOption, "i", instanceIDDefault, "The instance ID to identify this node")
 	jobs := flag.IntP(jobsOption, "j", jobsDefault, "Number of RPC jobs to run")
 	version := flag.BoolP(versionOption, "v", false, "Print version and exit")
-	DHTRouting := flag.Bool(DHTRoutingOption, DHTRoutingDefault, "Disables DHT routing")
+	dhtLocalDiscovery := flag.Bool(dhtLocalDiscoveryOption, dhtLocalDiscoveryDefault, "Enables local peer discovery")
 
 	flag.Parse()
 
@@ -124,7 +124,7 @@ func main() {
 	*logDatetime = util.GetBoolOption(logDatetimeOption, logDatetimeDefault, *logDatetime, yamlConfig.P2P, yamlConfig.Global)
 	*instanceID = util.GetStringOption(instanceIDOption, util.GenerateBase58ID(5), *instanceID, yamlConfig.P2P, yamlConfig.Global)
 	*jobs = util.GetIntOption(jobsOption, jobsDefault, *jobs, yamlConfig.P2P, yamlConfig.Global)
-	*DHTRouting = util.GetBoolOption(DHTRoutingOption, DHTRoutingDefault, *DHTRouting, yamlConfig.P2P, yamlConfig.Global)
+	*dhtLocalDiscovery = util.GetBoolOption(dhtLocalDiscoveryOption, dhtLocalDiscoveryDefault, *dhtLocalDiscovery, yamlConfig.P2P, yamlConfig.Global)
 
 	if len(*logDir) > 0 && !path.IsAbs(*logDir) {
 		*logDir = path.Join(util.GetAppDir(baseDir, appName), *logDir)
@@ -169,8 +169,8 @@ func main() {
 	if *forceGossip {
 		config.GossipToggleOptions.AlwaysEnable = true
 	}
-	if *DHTRouting {
-		config.NodeOptions.DHTRouting = true
+	if *dhtLocalDiscovery {
+		config.NodeOptions.DHTLocalDiscovery = true
 	}
 
 	for _, checkpoint := range *checkpoints {

--- a/internal/node/node.go
+++ b/internal/node/node.go
@@ -94,11 +94,6 @@ func NewKoinosP2PNode(ctx context.Context, listenAddr string, localRPC rpc.Local
 		libp2p.Identity(privateKey),
 		// Attempt to open ports using uPNP for NATed hosts.
 		libp2p.NATPortMap(),
-		// Let this host use the DHT to find other hosts
-		libp2p.Routing(func(h host.Host) (routing.PeerRouting, error) {
-			idht, err = dht.New(ctx, h)
-			return idht, err
-		}),
 		// Let this host use relays and advertise itself on relays if
 		// it finds it is behind NAT. Use libp2p.Relay(options...) to
 		// enable active relays and more.
@@ -114,6 +109,13 @@ func NewKoinosP2PNode(ctx context.Context, listenAddr string, localRPC rpc.Local
 		libp2p.EnableNATService(),
 		libp2p.ConnectionGater(node.PeerErrorHandler),
 		libp2p.ProtocolVersion(p2p.KoinosProtocolVersionString()),
+	}
+
+	if config.NodeOptions.DHTRouting {
+		options = append(options, libp2p.Routing(func(h host.Host) (routing.PeerRouting, error) {
+			idht, err = dht.New(ctx, h)
+			return idht, err
+		}))
 	}
 
 	host, err := libp2p.New(options...)

--- a/internal/options/node_options.go
+++ b/internal/options/node_options.go
@@ -10,15 +10,15 @@ type NodeOptions struct {
 	// Force gossip mode on startup
 	ForceGossip bool
 
-	// DHT Routing
-	DHTRouting bool
+	// DHT local peer discovery
+	DHTLocalDiscovery bool
 }
 
 // NewNodeOptions creates a NodeOptions object which controls how p2p works
 func NewNodeOptions() *NodeOptions {
 	return &NodeOptions{
-		InitialPeers: make([]peer.AddrInfo, 0),
-		ForceGossip:  false,
-		DHTRouting:   false,
+		InitialPeers:      make([]peer.AddrInfo, 0),
+		ForceGossip:       false,
+		DHTLocalDiscovery: false,
 	}
 }

--- a/internal/options/node_options.go
+++ b/internal/options/node_options.go
@@ -9,6 +9,9 @@ type NodeOptions struct {
 
 	// Force gossip mode on startup
 	ForceGossip bool
+
+	// DHT Routing
+	DHTRouting bool
 }
 
 // NewNodeOptions creates a NodeOptions object which controls how p2p works
@@ -16,5 +19,6 @@ func NewNodeOptions() *NodeOptions {
 	return &NodeOptions{
 		InitialPeers: make([]peer.AddrInfo, 0),
 		ForceGossip:  false,
+		DHTRouting:   false,
 	}
 }


### PR DESCRIPTION
Resolves #295.

## Brief description
Disables DHT routing with a flag, defaults to false. Needs testing. Do not merge.

## Checklist

- [ ] I have built this pull request locally
- [ ] I have ran the unit tests locally
- [ ] I have manually tested this pull request
- [x] I have reviewed my pull request
- [ ] I have added any relevant tests

## Demonstration
<!-- If applicable, attach screenshot or terminal output of working code -->
