### PR TITLE
#303: Cleanup applicator

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ jobs:
         - gcov2lcov -infile=internal.out -outfile=internal.info
         - gcov2lcov -infile=node.out -outfile=node.info
         - gcov2lcov -infile=p2p.out -outfile=p2p.info
-        - golangci-lint run --timeout=2m ./...
+        - golangci-lint run --timeout=4m ./...
       after_success:
         - coveralls-lcov --repo-token "$COVERALLS_REPO_TOKEN" --service-name travis-pro coverage.info
 

--- a/internal/p2p/applicator.go
+++ b/internal/p2p/applicator.go
@@ -159,7 +159,7 @@ func (a *Applicator) addBlockEntry(ctx context.Context, entry *blockEntry) {
 	}
 }
 
-func (a *Applicator) removeEntry(ctx context.Context, id string, err error) {
+func (a *Applicator) removeBlockEntry(ctx context.Context, id string, err error) {
 	if entry, ok := a.blocksById[id]; ok {
 		for _, ch := range entry.errChans {
 			select {
@@ -245,7 +245,7 @@ func (a *Applicator) handleBlockStatus(ctx context.Context, status *blockApplica
 	if status.err != nil && (errors.Is(status.err, p2perrors.ErrBlockState)) {
 		a.requestBlockApplication(ctx, status.block)
 	} else if status.err == nil || !errors.Is(status.err, p2perrors.ErrUnknownPreviousBlock) {
-		a.removeEntry(ctx, string(status.block.Id), status.err)
+		a.removeBlockEntry(ctx, string(status.block.Id), status.err)
 	}
 }
 
@@ -303,7 +303,7 @@ func (a *Applicator) handleForkHeads(ctx context.Context, forkHeads *broadcast.F
 	for h := oldLib + 1; h <= forkHeads.LastIrreversibleBlock.Height; h++ {
 		if ids, ok := a.blocksByHeight[h]; ok {
 			for id := range ids {
-				a.removeEntry(ctx, id, p2perrors.ErrBlockIrreversibility)
+				a.removeBlockEntry(ctx, id, p2perrors.ErrBlockIrreversibility)
 			}
 		}
 	}


### PR DESCRIPTION
Resolves #303

## Brief description
Renames the applicator instance to `a` and clarifies functions that operate on blocks (i.e. `addEntry` -> `addBlockEntry`).

## Checklist

- [X] I have built this pull request locally
- [X] I have ran the unit tests locally
- [X] I have manually tested this pull request
- [X] I have reviewed my pull request
- [ ] I have added any relevant tests

## Demonstration
<!-- If applicable, attach screenshot or terminal output of working code -->
