### PR TITLE
Cleanup contexts

### DIFF
--- a/internal/options/peer_connection_options.go
+++ b/internal/options/peer_connection_options.go
@@ -20,7 +20,7 @@ const (
 	blockRequestTimeoutDefault   = time.Second * time.Duration(blockRequestBatchSizeDefault*0.3) // Roughly calculated considering 30Mbps minimum upload speed and 1MB blocks
 	handshakeRetryTimeDefault    = time.Second * 6
 	syncedBlockDeltaDefault      = 5
-	syncedPingTimeDefault        = time.Second * 10
+	syncedSleepTimeDefault       = time.Second * 10
 )
 
 // PeerConnectionOptions are options for PeerConnection
@@ -33,7 +33,7 @@ type PeerConnectionOptions struct {
 	BlockRequestTimeout   time.Duration
 	HandshakeRetryTime    time.Duration
 	SyncedBlockDelta      uint64
-	SyncedPingTime        time.Duration
+	SyncedSleepTime       time.Duration
 }
 
 // NewPeerConnectionOptions returns default initialized PeerConnectionOptions
@@ -47,6 +47,6 @@ func NewPeerConnectionOptions() *PeerConnectionOptions {
 		BlockRequestTimeout:   blockRequestTimeoutDefault,
 		HandshakeRetryTime:    handshakeRetryTimeDefault,
 		SyncedBlockDelta:      syncedBlockDeltaDefault,
-		SyncedPingTime:        syncedPingTimeDefault,
+		SyncedSleepTime:       syncedSleepTimeDefault,
 	}
 }

--- a/internal/p2p/applicator.go
+++ b/internal/p2p/applicator.go
@@ -159,7 +159,7 @@ func (a *Applicator) addBlockEntry(ctx context.Context, entry *blockEntry) {
 	}
 }
 
-func (a *Applicator) removeEntry(ctx context.Context, id string, err error) {
+func (a *Applicator) removeBlockEntry(ctx context.Context, id string, err error) {
 	if entry, ok := a.blocksById[id]; ok {
 		for _, ch := range entry.errChans {
 			select {
@@ -245,7 +245,7 @@ func (a *Applicator) handleBlockStatus(ctx context.Context, status *blockApplica
 	if status.err != nil && (errors.Is(status.err, p2perrors.ErrBlockState)) {
 		a.requestBlockApplication(ctx, status.block)
 	} else if status.err == nil || !errors.Is(status.err, p2perrors.ErrUnknownPreviousBlock) {
-		a.removeEntry(ctx, string(status.block.Id), status.err)
+		a.removeBlockEntry(ctx, string(status.block.Id), status.err)
 	}
 }
 
@@ -303,7 +303,7 @@ func (a *Applicator) handleForkHeads(ctx context.Context, forkHeads *broadcast.F
 	for h := oldLib + 1; h <= forkHeads.LastIrreversibleBlock.Height; h++ {
 		if ids, ok := a.blocksByHeight[h]; ok {
 			for id := range ids {
-				a.removeEntry(ctx, id, p2perrors.ErrBlockIrreversibility)
+				a.removeBlockEntry(ctx, id, p2perrors.ErrBlockIrreversibility)
 			}
 		}
 	}


### PR DESCRIPTION
Resolves #304

## Brief description
Cleans up use of contexts to avoid leaking go routines when gossip is disabled or peers disconnect.

## Checklist

- [X] I have built this pull request locally
- [X] I have ran the unit tests locally
- [X] I have manually tested this pull request
- [X] I have reviewed my pull request
- [ ] I have added any relevant tests

## Demonstration
<!-- If applicable, attach screenshot or terminal output of working code -->
